### PR TITLE
Add a schema for t_status.tbl

### DIFF
--- a/packer/packer.py
+++ b/packer/packer.py
@@ -45,18 +45,20 @@ def pack(path=None, projectName=None, randomizer=False):
                                 length += 1
                             elif schema[key] == 's':
                                 length += 2
+                            elif schema[key] == 'S':
+                                length += 2
                             elif schema[key] == 'i' or schema[key] == 'f':
                                 length += 4
                             elif schema[key] == 't':
                                 length += len(entry[key].encode('utf-8')) + 1
-                            elif schema[key] == 'd':
+                            elif schema[key].startswith('d'):
                                 length += len(entry[key].split(' '))
                         dataFile.write(header.encode('utf-8'))
                         dataFile.write(b'\x00')
                         dataFile.write(length.to_bytes(2, 'little'))
 
                         for key in fieldNames:
-                            if schema[key] == 'd':
+                            if schema[key].startswith('d'):
                                 hexText = entry[key]
                                 hexText = hexText.replace(' ', '')
                                 byteText = bytes.fromhex(hexText)
@@ -65,6 +67,8 @@ def pack(path=None, projectName=None, randomizer=False):
                                 dataFile.write(int(entry[key]).to_bytes(1, 'little'))
                             elif schema[key] == 's':
                                 dataFile.write(int(entry[key]).to_bytes(2, 'little'))
+                            elif schema[key] == 'S':
+                                dataFile.write(int(entry[key]).to_bytes(2, 'little', signed=True))
                             elif schema[key] == 'i':
                                 dataFile.write(int(entry[key]).to_bytes(4, 'little'))
                             elif schema[key] == 'f':
@@ -96,18 +100,20 @@ def pack(path=None, projectName=None, randomizer=False):
                                                 length += 1
                                             elif moduleSchema[subKey] == 's':
                                                 length += 2
+                                            elif moduleSchema[subKey] == 'S':
+                                                length += 2
                                             elif moduleSchema[subKey] == 'i' or moduleSchema[subKey] == 'f':
                                                 length += 4
                                             elif moduleSchema[subKey] == 't':
                                                 length += len(subEntry[subKey].encode('utf-8')) + 1
-                                            elif moduleSchema[subKey] == 'd':
+                                            elif moduleSchema[subKey].startswith('d'):
                                                 length += len(subEntry[subKey].split(' '))
                                         dataFile.write(moduleName.encode('utf-8'))
                                         dataFile.write(b'\x00')
                                         dataFile.write(length.to_bytes(2, 'little'))
 
                                         for subKey in subFieldNames:
-                                            if moduleSchema[subKey] == 'd':
+                                            if moduleSchema[subKey].startswith('d'):
                                                 hexText = subEntry[subKey]
                                                 hexText = hexText.replace(' ', '')
                                                 byteText = bytes.fromhex(hexText)
@@ -116,6 +122,8 @@ def pack(path=None, projectName=None, randomizer=False):
                                                 dataFile.write(int(subEntry[subKey]).to_bytes(1, 'little'))
                                             elif moduleSchema[subKey] == 's':
                                                 dataFile.write(int(subEntry[subKey]).to_bytes(2, 'little'))
+                                            elif moduleSchema[subKey] == 'S':
+                                                dataFile.write(int(subEntry[subKey]).to_bytes(2, 'little', signed=True))
                                             elif moduleSchema[subKey] == 'i':
                                                 dataFile.write(int(subEntry[subKey]).to_bytes(4, 'little'))
                                             elif moduleSchema[subKey] == 'f':

--- a/schema/status.py
+++ b/schema/status.py
@@ -1,0 +1,123 @@
+status_p = {
+    "character_id": "s",
+    "text_1" : "t",
+    "texture" : "t",
+    "model": "t",
+    "float_1": "f",
+    "float_2": "f",
+    "float_3": "f",
+    "float_4": "f",
+    "float_5": "f",
+    "float_6": "f",
+    "float_7": "f",
+    "short_1": "s",
+    "short_2": "s",
+    "is_female": "b",
+    "level": "b",
+    "hp_base": "i",
+    "hp_growth": "f",
+    "max_ep": "s",
+    "start_ep": "s",
+    "max_cp": "s",
+    "start_cp": "s",
+    "str_base": "s",
+    "str_growth": "f",
+    "def_base": "s",
+    "def_growth": "f",
+    "ats_base": "s",
+    "ats_growth": "f",
+    "adf_base": "s",
+    "adf_growth": "f",
+    "dex_base": "s",
+    "dex_growth": "f",
+    "agi_base": "s",
+    "agi_growth": "f",
+    "eva": "s",
+    "spd_base": "s",
+    "spd_growth": "f",
+    "mov_base": "s",
+    "mov_growth": "f",
+
+    "exp_base": "s",
+    "exp_growth": "f",
+    "break_multiplier_base": "s",
+    "break_multiplier_growth": "f",
+    "earth_efficacy" : "b",
+    "water_efficacy" : "b",
+    "fire_efficacy" : "b",
+    "wind_efficacy" : "b",
+    "time_efficacy" : "b",
+    "space_efficacy" : "b",
+    "mirage_efficacy" : "b",
+
+    "psn_efficacy" : "b",
+    "seal_efficacy" : "b",
+    "mute_efficacy" : "b",
+    "blnd_efficacy" : "b",
+    "slp_efficacy" : "b",
+    "burn_efficacy" : "b",
+    "frz_efficacy" : "b",
+    "petr_efficacy" : "b",
+    "fnt_efficacy" : "b",
+    "conf_efficacy" : "b",
+    "chrm_efficacy" : "b",
+    "dblw_efficacy" : "b",
+    "nmr_efficacy" : "b",
+    "dlay_efficacy" : "b",
+    "vnsh_efficacy" : "b",
+    "s-dwn_efficacy" : "b",
+
+    "slash_efficacy" : "s",
+    "thurst_efficacy" : "s",
+    "pierce_efficacy" : "s",
+    "strike_efficacy" : "s",
+
+    "zeros_1": "d46",
+
+    "float_8": "f",
+    "float_9": "f",
+    "text_2": "t",
+    "name": "t",
+    "text_3": "t",
+}
+
+status_revise = {
+    # These values are only used in hard and nightmare
+    "difficulty_id": "s",
+    "hp": "s",
+    "str": "s",
+    "def": "s",
+    "ats": "s",
+    "adf": "s",
+    "spd": "s",
+    "brk": "s",
+}
+
+char_revise = {
+    # These values are only used in hard and nightmare
+    "enemy_script": "t",
+    "hp": "s",
+    "str": "s",
+    "def": "s",
+    "ats": "s",
+    "adf": "s",
+    "spd": "s",
+    "brk": "s"
+}
+
+game_difficulty = {
+    "difficulty_id": "s",
+    "difficulty_multiplier": "S"
+}
+
+field_attack_data = {
+    "short_1": "s",
+    "byte_1": "b",
+    "float_1": "f",
+    "float_2": "f",
+    "float_3": "f",
+    "float_4": "f",
+    "data": "d",
+}
+
+headers = ["status_p", "status_revise", "char_revise", "game_difficulty", "field_attack_data"]

--- a/unpacker/unpacker.py
+++ b/unpacker/unpacker.py
@@ -3,7 +3,7 @@ import importlib, collections
 import csv, json, struct
 
 def unpack(path=None, projectName=None):
-    moduleList = ['magic']
+    moduleList = ['magic', 'status']
     for name in moduleList:
         file = f'{path}/data/text/dat_en/t_{name}.tbl'
         outputPath = f'projects/{projectName}/text/{name}/'
@@ -64,15 +64,20 @@ def unpack(path=None, projectName=None):
                 row = {}
 
                 for key in fieldNames:
-                    if schema[key] == 'd':
-                        hexText = headerData.read().hex()
+                    if schema[key].startswith('d'):
+                        if len(schema[key]) > 1:
+                            n = int(schema[key][1:])
+                            hexText = headerData.read(n).hex()
+                        else:
+                            hexText = headerData.read().hex()
                         hexText = ' '.join(hexText[j:j+2] for j in range(0, len(hexText), 2)).upper()
                         rowData.append(hexText)
-                        break
                     elif schema[key] == 'b':
                         rowData.append(int.from_bytes(headerData.read(1), 'little'))
                     elif schema[key] == 's':
                         rowData.append(int.from_bytes(headerData.read(2), 'little'))
+                    elif schema[key] == 'S':
+                        rowData.append(int.from_bytes(headerData.read(2), 'little', signed=True))
                     elif schema[key] == 'i':
                         rowData.append(int.from_bytes(headerData.read(4), 'little'))
                     elif schema[key] == 'f':
@@ -129,15 +134,20 @@ def unpack(path=None, projectName=None):
                                 subRow = {}
 
                                 for subKey in subFieldNames:
-                                    if moduleSchema[subKey] == 'd':
-                                        hexText = subData.read().hex()
+                                    if moduleSchema[subKey].startswith('d'):
+                                        if len(moduleSchema[subKey]) > 1:
+                                            n = int(moduleSchema[subKey][1:])
+                                            hexText = subData.read(n).hex()
+                                        else:
+                                            hexText = subData.read().hex()
                                         hexText = ' '.join(hexText[j:j+2] for j in range(0, len(hexText), 2)).upper()
                                         subRowData.append(hexText)
-                                        break
                                     elif moduleSchema[subKey] == 'b':
                                         subRowData.append(int.from_bytes(subData.read(1), 'little'))
                                     elif moduleSchema[subKey] == 's':
                                         subRowData.append(int.from_bytes(subData.read(2), 'little'))
+                                    elif moduleSchema[subKey] == 'S':
+                                        subRowData.append(int.from_bytes(subData.read(2), 'little', signed=True))
                                     elif moduleSchema[subKey] == 'i':
                                         subRowData.append(int.from_bytes(subData.read(4), 'little'))
                                     elif moduleSchema[subKey] == 'f':


### PR DESCRIPTION
This commit also adds two new field types:

- 'S' for a signed short. This is required for the difficulty modifiers
  in game_difficulty.

- 'dN' (where N is an integer > 0) for N bytes of data. This is needed
  for a stretch of null bytes in status_p. I also found it useful for
  developing the schema one field at a time.

I have not tested the efficacy fields in status_p, but according to
SoftBrilliant the schema is the same as that of status in t_mons.tbl
and the values seem reasonable.